### PR TITLE
Handle exceptions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Options can include the following. apikey is required.
 * __apikey:__ apikey for the Pushbullet account that will recieve the notification.
 * __level:__ Level of warning required for a notification to be sent off. Defaults to warn.
 * __title__ Title of the notification. Defaults to 'Winston Notification'.
+* __handleExceptions Let unhandled exceptions get logged. Defaults to 'false'.
 * __devices__ Devices to send the notifications too. As per the `node-pushbullet-api` module both device IDENs and device IDs can be used.  If the `deviceIden` parameter is passed as a number it is treated as a device ID. It defaults to `''` which means the notification will be sent to all devices on the account.
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Options can include the following. apikey is required.
 
 * __apikey:__ apikey for the Pushbullet account that will recieve the notification.
 * __level:__ Level of warning required for a notification to be sent off. Defaults to warn.
-* __title__ Title of the notification. Defaults to 'Winston Notification'.
-* __handleExceptions Let unhandled exceptions get logged. Defaults to 'false'.
-* __devices__ Devices to send the notifications too. As per the `node-pushbullet-api` module both device IDENs and device IDs can be used.  If the `deviceIden` parameter is passed as a number it is treated as a device ID. It defaults to `''` which means the notification will be sent to all devices on the account.
+* __title:__ Title of the notification. Defaults to 'Winston Notification'.
+* __handleExceptions:__ Let unhandled exceptions get logged. Defaults to 'false'.
+* __devices:__ Devices to send the notifications too. As per the `node-pushbullet-api` module both device IDENs and device IDs can be used.  If the `deviceIden` parameter is passed as a number it is treated as a device ID. It defaults to `''` which means the notification will be sent to all devices on the account.
 
 ## Dependencies
 

--- a/lib/winston-pushbullet.js
+++ b/lib/winston-pushbullet.js
@@ -10,6 +10,7 @@ var Pushbullet  = exports.Pushbullet = function (options) {
   this.title = options.title || 'Winston Notification';
   this.apikey = options.apikey;
   this.devices = options.devices || '';
+  this.handleExceptions = options.handleExceptions || false;
 };
 
 //


### PR DESCRIPTION
I find it very powerful to get a Pushbullet when something in production breaks. Hence this contribution: Let winston-pushbullte handle uncaught exceptions.
